### PR TITLE
feat: Disable NotificationPermission check from Lint since the app do…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,11 @@ android {
         setProperty("archivesBaseName", "Asteroid Radar" + "_v_" + defaultConfig.versionName)
 
     }
+
+    lintOptions {
+        disable("NotificationPermission")
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
…esn't have a notification feature.

The glide library's last version internally references notification functionality (NotificationTarget), and it makes the ci fail in the Lint step.