### PR TITLE
feat: Add compose compiler plugin to project

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose)
     alias(libs.plugins.kotlin)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.kapt)

--- a/build.gradle
+++ b/build.gradle
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin) apply false
     alias(libs.plugins.safe.args) apply false
     alias(libs.plugins.gradle.plugin.secret) apply false
+    alias(libs.plugins.compose) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 activityComposeVersion = "1.10.0"
 composeBomVersion = "2025.01.01"
+composePluginVersion = "2.1.0"
 kotlinVersion = '2.1.0'
 koinVersion = '4.0.0'
 coreVersion = '1.15.0'
@@ -75,6 +76,7 @@ picasso = { group = "com.squareup.picasso", name = "picasso", version.ref = "pic
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradleToolsVersion" }
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
+compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "composePluginVersion" }
 safe-args = { id = "androidx.navigation.safeargs.kotlin", version.ref = "safeArgsVersion" }
 gradle-plugin-secret = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "gradlePluginSecretVersion" }
 kotlin-android = { id = "kotlin-android" }


### PR DESCRIPTION
- Added the Compose compiler plugin to the project.
- Updated `libs.versions.toml` with the `composePluginVersion` and added the Compose plugin to the plugins section.
- Applied the Compose plugin in `app/build.gradle` and the root `build.gradle`.